### PR TITLE
Add Automatic Walk-Time Tables to "In Development"

### DIFF
--- a/in-development.md
+++ b/in-development.md
@@ -6,4 +6,13 @@ weight: 2
 ---
 
 # Webtools in Entwicklung
-Hier zeigen wir euch bald, an welchen neuen spannenden Projekten wir arbeiten.
+## J+S-Marschzeittabellen automatisiert generieren
+![Banner](https://github.com/cevi/automatic_walk-time_tables/raw/master/imgs/Claim.png)
+Ziel dieses Projektes ist es, den Prozess rund um das Erstellen einer J+S-Marschzeittabelle für eine Wanderung oder Velo-Tour zu automatisieren und zu beschleunigen.
+
+Features
+- Einlesen von GPX Dateien
+- J+S-Marschzeittabelle (Excel) automatisiert generieren
+- Karten mit gewähltem Massstab als PDF generieren
+
+Das Projekt ist unter [cevi/automatic_walk-time_tables](https://github.com/cevi/automatic_walk-time_tables) zu finden.


### PR DESCRIPTION
This PR adds the repo https://github.com/cevi/automatic_walk-time_tables to the "In Entwicklung" page.